### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,5 +1,5 @@
 ---
-title:"Set up a Sonatype Nexus connector"
+title: "Set up a Sonatype Nexus connector"
 og:title: "Set up a Sonatype Nexus connector"
 og:description: Integrate your Nexus instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
 description: C1 provides identity governance for Sonatype Nexus. Integrate your Nexus instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Set up a Nexus connector"
-og:title: Set up an Sonatype Nexus connector - C1 docs
+title:"Set up a Sonatype Nexus connector"
+og:title: "Set up a Sonatype Nexus connector"
 og:description: Integrate your Nexus instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
 description: C1 provides identity governance for Sonatype Nexus. Integrate your Nexus instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
 sidebarTitle: "Sonatype Nexus"
@@ -37,7 +37,7 @@ The host URL of your Nexus instance (for example: `https://nexus.company.com`).
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Nexus connector
 
@@ -90,7 +90,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Nexus connector is now pulling access data into C1.
+**Done.** Your Nexus connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Nexus connector, hosted and run in your own environment. **
@@ -209,7 +209,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Nexus connector is now pulling access data into C1.
+**Done.** Your Nexus connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`