### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -37,15 +37,14 @@ func (o *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 			"name":             role.Name,
 		}
 
-		roleTraits := []resource.RoleTraitOption{
-			resource.WithRoleProfile(profile),
-		}
+		roleTraits := []resource.RoleTraitOption{}
 
 		roleResource, err := resource.NewRoleResource(
 			role.ID,
 			roleResourceType,
 			role.Name,
 			roleTraits,
+			resource.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("error creating role resource: %w", err)

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -43,7 +43,6 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		}
 
 		userTraits := []resource.UserTraitOption{
-			resource.WithUserProfile(profile),
 			resource.WithEmail(user.EmailAddress, true),
 		}
 
@@ -52,6 +51,7 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 			userResourceType,
 			user.UserID,
 			userTraits,
+			resource.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("error creating user resource: %w", err)
@@ -223,7 +223,6 @@ func (o *userBuilder) userToResource(user *client.User) (*v2.Resource, error) {
 	}
 
 	userTraits := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
 		resource.WithEmail(user.EmailAddress, true),
 	}
 
@@ -232,6 +231,7 @@ func (o *userBuilder) userToResource(user *client.User) (*v2.Resource, error) {
 		userResourceType,
 		user.UserID,
 		userTraits,
+		resource.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating user resource: %w", err)


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
